### PR TITLE
duckdb-python.py: fix to run without errors

### DIFF
--- a/examples/python/duckdb-python.py
+++ b/examples/python/duckdb-python.py
@@ -98,7 +98,7 @@ print(rel.limit(2))
 print(rel.limit(2, offset=1))
 
 # of course these things can be chained
-print(rel.filter('i > 1').project('i + 1').order('j').limit(2))
+print(rel.filter('i > 1').project('i + 1, j').order('j').limit(2))
 
 # aggregate the relation
 print(rel.aggregate("sum(i)"))
@@ -134,7 +134,7 @@ print(duckdb.aggregate(test_df, "sum(i)"))
 print(duckdb.distinct(test_df))
 
 # when chaining only the first call needs to include the data frame parameter
-print(duckdb.filter(test_df, 'i > 1').project('i + 1').order('j').limit(2))
+print(duckdb.filter(test_df, 'i > 1').project('i + 1, j').order('j').limit(2))
 
 # turn the relation into something else again
 
@@ -176,13 +176,10 @@ res = rel.query('my_name_for_rel', 'SELECT * FROM my_name_for_rel')
 print(res)
 # res is a query result, we can fetch with the methods described above, e.g.
 print(res.fetchone())
-print(res.fetchdf())
+print(res.execute().fetchdf())
 # or just use df(), a shorthand for fetchdf() on query results
 print(res.df())
 
 # this also works directly on data frames
 res = duckdb.query(test_df, 'my_name_for_test_df', 'SELECT * FROM my_name_for_test_df')
 print(res.df())
-
-
-


### PR DESCRIPTION
The main confusion seem to stem from the fact that at the end `res` is a `DuckDBPyRelation` and not a `DuckDBPyResult`. Actually `res` seems to be the wrong variable name in this case...

So maybe it would be best for somebody knowledgable to revisit this file.